### PR TITLE
Update readme to include  Docker Pipeline Plugin requirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Once Jenkins restarts you can login with `admin/<admin password>`
 ## Configuring Jenkins
 With Jenkins running locally we are ready to configure the pipeline. The repository that you cloned has a Jenkinsfile that already defines the pipeline we are going to run. That Jenkinsfile makes use of both Environment Variables and Secret Credentials that we will need to set up before configuring the job. Let’s get those going...
 
+## Install Docker Plugins
+You will need to install Docker Plugin and Docker Pipeline plugins. Go to the [Manage Jenkins plugins] http://localhost:8080/pluginManager/ page. Search for
+Docker and Docker Pipeline plugins.
+
 ### Environment Variables
 We are going to define three global environments variables. Those variables are as follows:
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ After that you can just click **"Restart"** to finish the initial setup. _(Note:
 
 Once Jenkins restarts you can login with `admin/<admin password>`
 
+## Additonal Plugin requirement
+You will need to install **Docker Pipeline** plugin. This plugin allows you to build, test, and use Docker images from Jenkins Pipeline project. 
+Go to the [Manage Jenkins plugins] http://localhost:8080/pluginManager/ page, search for Docker Pipeline plugin under the **Available tab**,  
+click the checkbox adjancent to Docker pipeline plugin, and finally click on the **Download now and install after restart** button.
+
 ## Configuring Jenkins
 With Jenkins running locally we are ready to configure the pipeline. The repository that you cloned has a Jenkinsfile that already defines the pipeline we are going to run. That Jenkinsfile makes use of both Environment Variables and Secret Credentials that we will need to set up before configuring the job. Let’s get those going...
 
-## Install Docker Plugins
-You will need to install Docker Plugin and Docker Pipeline plugins. Go to the [Manage Jenkins plugins] http://localhost:8080/pluginManager/ page. Search for
-Docker and Docker Pipeline plugins.
+
 
 ### Environment Variables
 We are going to define three global environments variables. Those variables are as follows:


### PR DESCRIPTION
Without the Docker Pipeline plugin, pipeline execution fails with the following error:
Invalid agent type "docker" specified. Must be one of [any, label, none].